### PR TITLE
Added jet hadronFlavor (keeping partonFlavor as jet_flavor)

### DIFF
--- a/AnalysisCode/interface/YggdrasilEventVars.h
+++ b/AnalysisCode/interface/YggdrasilEventVars.h
@@ -275,8 +275,8 @@ struct yggdrasilEventVars{
   vdouble jet_vtx3DVal_[rNumSys];
   vdouble jet_vtx3DSig_[rNumSys];
   vint jet_genId_[rNumSys];
+  vint jet_partonflavour_[rNumSys];
   vint jet_flavour_[rNumSys];
-  vint jet_hadronflavour_[rNumSys];
   vint jet_genParentId_[rNumSys];
   vint jet_genGrandParentId_[rNumSys];
 
@@ -296,22 +296,22 @@ struct yggdrasilEventVars{
   vdouble jet_loose_vtx3DVal_[rNumSys];
   vdouble jet_loose_vtx3DSig_[rNumSys];  
   vdouble jet_loose_pileupJetId_fullDiscriminant_[rNumSys];
+  vint jet_loose_partonflavour_[rNumSys];
   vint jet_loose_flavour_[rNumSys];
-  vint jet_loose_hadronflavour_[rNumSys];
 
   // temp loose jets
   vvdouble jet_temp_loose_vect_TLV_[rNumSys];
   vdouble jet_temp_loose_CSV_[rNumSys];
   vint jet_temp_loose_flavour_[rNumSys];
-  vint jet_temp_loose_hadronflavour_[rNumSys];
+  vint jet_temp_loose_partonflavour_[rNumSys];
 
   // no cc loose jets
   vvdouble jet_nocc_loose_vect_TLV_[rNumSys];
   vdouble jet_nocc_loose_CSV_[rNumSys];
   vdouble jet_nocc_loose_combinedMVABJetTags_[rNumSys];
   vdouble jet_nocc_loose_combinedInclusiveSecondaryVertexV2BJetTags_[rNumSys];
+  vint jet_nocc_loose_partonflavour_[rNumSys];
   vint jet_nocc_loose_flavour_[rNumSys];
-  vint jet_nocc_loose_hadronflavour_[rNumSys];
 
   // additional BDTvars
   double maxeta_jet_jet_[rNumSys];  
@@ -594,8 +594,8 @@ void yggdrasilEventVars::initialize(){
     jet_vtxNtracks_[iSys].clear();
     jet_vtx3DVal_[iSys].clear();
     jet_vtx3DSig_[iSys].clear();
+    jet_partonflavour_[iSys].clear();
     jet_flavour_[iSys].clear();
-    jet_hadronflavour_[iSys].clear();
     jet_genId_[iSys].clear();
     jet_genParentId_[iSys].clear();
     jet_genGrandParentId_[iSys].clear();
@@ -608,20 +608,20 @@ void yggdrasilEventVars::initialize(){
     jet_loose_vtxNtracks_[iSys].clear();
     jet_loose_vtx3DVal_[iSys].clear();
     jet_loose_vtx3DSig_[iSys].clear();
+    jet_loose_partonflavour_[iSys].clear();
     jet_loose_flavour_[iSys].clear();
-    jet_loose_hadronflavour_[iSys].clear();
 
     jet_temp_loose_vect_TLV_[iSys].clear();
     jet_temp_loose_CSV_[iSys].clear();
+    jet_temp_loose_partonflavour_[iSys].clear();
     jet_temp_loose_flavour_[iSys].clear();
-    jet_temp_loose_hadronflavour_[iSys].clear();
 
     jet_nocc_loose_vect_TLV_[iSys].clear();
     jet_nocc_loose_CSV_[iSys].clear();
     jet_nocc_loose_combinedMVABJetTags_[iSys].clear();
     jet_nocc_loose_combinedInclusiveSecondaryVertexV2BJetTags_[iSys].clear();
+    jet_nocc_loose_partonflavour_[iSys].clear();
     jet_nocc_loose_flavour_[iSys].clear();
-    jet_nocc_loose_hadronflavour_[iSys].clear();
 
     IsTauTauLeptonEvent_[iSys] = -99;
 

--- a/AnalysisCode/interface/YggdrasilEventVars.h
+++ b/AnalysisCode/interface/YggdrasilEventVars.h
@@ -276,6 +276,7 @@ struct yggdrasilEventVars{
   vdouble jet_vtx3DSig_[rNumSys];
   vint jet_genId_[rNumSys];
   vint jet_flavour_[rNumSys];
+  vint jet_hadronflavour_[rNumSys];
   vint jet_genParentId_[rNumSys];
   vint jet_genGrandParentId_[rNumSys];
 
@@ -296,11 +297,13 @@ struct yggdrasilEventVars{
   vdouble jet_loose_vtx3DSig_[rNumSys];  
   vdouble jet_loose_pileupJetId_fullDiscriminant_[rNumSys];
   vint jet_loose_flavour_[rNumSys];
+  vint jet_loose_hadronflavour_[rNumSys];
 
   // temp loose jets
   vvdouble jet_temp_loose_vect_TLV_[rNumSys];
   vdouble jet_temp_loose_CSV_[rNumSys];
   vint jet_temp_loose_flavour_[rNumSys];
+  vint jet_temp_loose_hadronflavour_[rNumSys];
 
   // no cc loose jets
   vvdouble jet_nocc_loose_vect_TLV_[rNumSys];
@@ -308,6 +311,7 @@ struct yggdrasilEventVars{
   vdouble jet_nocc_loose_combinedMVABJetTags_[rNumSys];
   vdouble jet_nocc_loose_combinedInclusiveSecondaryVertexV2BJetTags_[rNumSys];
   vint jet_nocc_loose_flavour_[rNumSys];
+  vint jet_nocc_loose_hadronflavour_[rNumSys];
 
   // additional BDTvars
   double maxeta_jet_jet_[rNumSys];  
@@ -591,6 +595,7 @@ void yggdrasilEventVars::initialize(){
     jet_vtx3DVal_[iSys].clear();
     jet_vtx3DSig_[iSys].clear();
     jet_flavour_[iSys].clear();
+    jet_hadronflavour_[iSys].clear();
     jet_genId_[iSys].clear();
     jet_genParentId_[iSys].clear();
     jet_genGrandParentId_[iSys].clear();
@@ -604,16 +609,19 @@ void yggdrasilEventVars::initialize(){
     jet_loose_vtx3DVal_[iSys].clear();
     jet_loose_vtx3DSig_[iSys].clear();
     jet_loose_flavour_[iSys].clear();
+    jet_loose_hadronflavour_[iSys].clear();
 
     jet_temp_loose_vect_TLV_[iSys].clear();
     jet_temp_loose_CSV_[iSys].clear();
     jet_temp_loose_flavour_[iSys].clear();
+    jet_temp_loose_hadronflavour_[iSys].clear();
 
     jet_nocc_loose_vect_TLV_[iSys].clear();
     jet_nocc_loose_CSV_[iSys].clear();
     jet_nocc_loose_combinedMVABJetTags_[iSys].clear();
     jet_nocc_loose_combinedInclusiveSecondaryVertexV2BJetTags_[iSys].clear();
     jet_nocc_loose_flavour_[iSys].clear();
+    jet_nocc_loose_hadronflavour_[iSys].clear();
 
     IsTauTauLeptonEvent_[iSys] = -99;
 

--- a/YggdrasilTreeMaker/plugins/YggdrasilTreeMaker.cc
+++ b/YggdrasilTreeMaker/plugins/YggdrasilTreeMaker.cc
@@ -1917,6 +1917,7 @@ if(n_fatjets==2)pt_fatjet_2=topJet->fatjet.pt();
 
     vint jet_genId_vect;
     vint jet_flavour_vect;
+    vint jet_hadronflavour_vect;
     vint jet_genParentId_vect;
     vint jet_genGrandParentId_vect;
 
@@ -1925,6 +1926,7 @@ int jcntn=0;
     for( std::vector<pat::Jet>::const_iterator iJet = selectedJets.begin(); iJet != selectedJets.end(); iJet++ ){ 
 jcntn++;
       jet_flavour_vect.push_back(iJet->partonFlavour());
+      jet_hadronflavour_vect.push_back(iJet->hadronFlavour());
 
       int genPartonId=-99, genPartonMotherId=-99, genPartonGrandMotherId=-99;
       if( (iJet->genParton()) ){ // if there is a matched parton, fill variables
@@ -2049,6 +2051,7 @@ jcntn++;
     std::vector<double> jet_loose_vtx3DSig;
     std::vector<double> jet_loose_pileupJetId_fullDiscriminant;
     vint jet_flavour_vect_loose;
+    vint jet_hadronflavour_vect_loose;
     vecTLorentzVector jetV_loose;
 
     int numJet_loose = 0;
@@ -2087,6 +2090,7 @@ jcntn++;
 
       numJet_loose++;
       jet_flavour_vect_loose.push_back(iJet->partonFlavour());
+      jet_hadronflavour_vect_loose.push_back(iJet->hadronFlavour());
 
       jet_loose_vtxMass.push_back(iJet->userFloat("vtxMass"));
       jet_loose_vtxNtracks.push_back(iJet->userFloat("vtxNtracks"));
@@ -2439,6 +2443,7 @@ jcntn++;
     eve->jet_vtx3DVal_[iSys]   = jet_vtx3DVal;
     eve->jet_vtx3DSig_[iSys]   = jet_vtx3DSig;
     eve->jet_flavour_[iSys]          = jet_flavour_vect;
+    eve->jet_hadronflavour_[iSys]          = jet_hadronflavour_vect;
     eve->jet_genId_[iSys]            = jet_genId_vect;
     eve->jet_genParentId_[iSys]      = jet_genParentId_vect;
     eve->jet_genGrandParentId_[iSys] = jet_genGrandParentId_vect;
@@ -2459,6 +2464,7 @@ jcntn++;
     eve->jet_loose_vtx3DSig_[iSys]   = jet_loose_vtx3DSig;
     eve->jet_loose_pileupJetId_fullDiscriminant_[iSys] = jet_loose_pileupJetId_fullDiscriminant;
     eve->jet_loose_flavour_[iSys]  = jet_flavour_vect_loose;
+    eve->jet_loose_hadronflavour_[iSys]  = jet_hadronflavour_vect_loose;
 
 
    

--- a/YggdrasilTreeMaker/plugins/YggdrasilTreeMaker.cc
+++ b/YggdrasilTreeMaker/plugins/YggdrasilTreeMaker.cc
@@ -1916,8 +1916,8 @@ if(n_fatjets==2)pt_fatjet_2=topJet->fatjet.pt();
 
 
     vint jet_genId_vect;
+    vint jet_partonflavour_vect;
     vint jet_flavour_vect;
-    vint jet_hadronflavour_vect;
     vint jet_genParentId_vect;
     vint jet_genGrandParentId_vect;
 
@@ -1925,8 +1925,8 @@ int jcntn=0;
     // Loop over selected jets
     for( std::vector<pat::Jet>::const_iterator iJet = selectedJets.begin(); iJet != selectedJets.end(); iJet++ ){ 
 jcntn++;
-      jet_flavour_vect.push_back(iJet->partonFlavour());
-      jet_hadronflavour_vect.push_back(iJet->hadronFlavour());
+      jet_partonflavour_vect.push_back(iJet->partonFlavour());
+      jet_flavour_vect.push_back(iJet->hadronFlavour());
 
       int genPartonId=-99, genPartonMotherId=-99, genPartonGrandMotherId=-99;
       if( (iJet->genParton()) ){ // if there is a matched parton, fill variables
@@ -2050,8 +2050,8 @@ jcntn++;
     std::vector<double> jet_loose_vtx3DVal;
     std::vector<double> jet_loose_vtx3DSig;
     std::vector<double> jet_loose_pileupJetId_fullDiscriminant;
+    vint jet_partonflavour_vect_loose;
     vint jet_flavour_vect_loose;
-    vint jet_hadronflavour_vect_loose;
     vecTLorentzVector jetV_loose;
 
     int numJet_loose = 0;
@@ -2089,8 +2089,8 @@ jcntn++;
       //if( iJet->pt()>=30. ) continue;
 
       numJet_loose++;
-      jet_flavour_vect_loose.push_back(iJet->partonFlavour());
-      jet_hadronflavour_vect_loose.push_back(iJet->hadronFlavour());
+      jet_partonflavour_vect_loose.push_back(iJet->partonFlavour());
+      jet_flavour_vect_loose.push_back(iJet->hadronFlavour());
 
       jet_loose_vtxMass.push_back(iJet->userFloat("vtxMass"));
       jet_loose_vtxNtracks.push_back(iJet->userFloat("vtxNtracks"));
@@ -2442,8 +2442,8 @@ jcntn++;
     eve->jet_vtxNtracks_[iSys] = jet_vtxNtracks;
     eve->jet_vtx3DVal_[iSys]   = jet_vtx3DVal;
     eve->jet_vtx3DSig_[iSys]   = jet_vtx3DSig;
+    eve->jet_partonflavour_[iSys]          = jet_partonflavour_vect;
     eve->jet_flavour_[iSys]          = jet_flavour_vect;
-    eve->jet_hadronflavour_[iSys]          = jet_hadronflavour_vect;
     eve->jet_genId_[iSys]            = jet_genId_vect;
     eve->jet_genParentId_[iSys]      = jet_genParentId_vect;
     eve->jet_genGrandParentId_[iSys] = jet_genGrandParentId_vect;
@@ -2463,8 +2463,8 @@ jcntn++;
     eve->jet_loose_vtx3DVal_[iSys]   = jet_loose_vtx3DVal;
     eve->jet_loose_vtx3DSig_[iSys]   = jet_loose_vtx3DSig;
     eve->jet_loose_pileupJetId_fullDiscriminant_[iSys] = jet_loose_pileupJetId_fullDiscriminant;
+    eve->jet_loose_partonflavour_[iSys]  = jet_partonflavour_vect_loose;
     eve->jet_loose_flavour_[iSys]  = jet_flavour_vect_loose;
-    eve->jet_loose_hadronflavour_[iSys]  = jet_hadronflavour_vect_loose;
 
 
    


### PR DESCRIPTION

![screen shot 2016-02-10 at 1 45 17 pm](https://cloud.githubusercontent.com/assets/8107015/12947578/9a04fb34-cffc-11e5-91d7-b51eec267a15.png)
New variable _jet_hadronflavor_ are added into the output tuple file.
In the current tool, variable _jet_flavor_ carries the output of jet->partonFlavor().
For backward compatibility, I prefer to keep the variable as it is.
That is ; 
 _jet_flavor_ : jet->partonFlavor 
 _jet_hadronflavor_ : jet->hadronFlavor [new variable]

Attached picture : 
 - red : abs(jet_flav)
 - blue : jet_hadronflav
 of jets with idx=0 in 100 ttbar mc events.