### PR TITLE
updated YggdrasilTreeMaker.cc according to update of MiniAODHeler int…

### DIFF
--- a/YggdrasilTreeMaker/plugins/YggdrasilTreeMaker.cc
+++ b/YggdrasilTreeMaker/plugins/YggdrasilTreeMaker.cc
@@ -845,7 +845,7 @@ YggdrasilTreeMaker::analyze(const edm::Event& iEvent, const edm::EventSetup& iSe
   std::vector<pat::Jet> rawJets = miniAODhelper.GetUncorrectedJets( pfJets_ID );
  // std::vector<pat::Jet> jetsNoMu = miniAODhelper.RemoveOverlaps(selectedMuons_loose, rawJets_ID);
  // std::vector<pat::Jet> jetsNoEle = miniAODhelper.RemoveOverlaps(selectedElectrons_loose, jetsNoMu);
-  std::vector<pat::Jet> correctedJets_noSys = miniAODhelper.GetCorrectedJets(rawJets, iEvent, iSetup);
+  std::vector<pat::Jet> correctedJets_noSys = miniAODhelper.GetCorrectedJets(rawJets, iEvent, iSetup, genjetCollection );
   std::vector<pat::Jet> selectedJets_noSys_unsorted = miniAODhelper.GetSelectedJets(correctedJets_noSys, 20., 5.0, jetID::none, '-' );
   std::vector<pat::Jet> selectedJets_tag_noSys_unsorted = miniAODhelper.GetSelectedJets( correctedJets_noSys, 30., 2.4, jetID::none, 'M' );
 
@@ -1265,7 +1265,7 @@ YggdrasilTreeMaker::analyze(const edm::Event& iEvent, const edm::EventSetup& iSe
     ///
     ////////
 
-    std::vector<pat::Jet> correctedJets = ( !(iSys>=5 && iSys<=8) ) ? correctedJets_noSys : miniAODhelper.GetCorrectedJets(rawJets, iEvent, iSetup, iSysType);
+    std::vector<pat::Jet> correctedJets = ( !(iSys>=5 && iSys<=8) ) ? correctedJets_noSys : miniAODhelper.GetCorrectedJets(rawJets, iEvent, iSetup, genjetCollection , iSysType);
     std::vector<pat::Jet> selectedJets_unsorted = ( !(iSys>=5 && iSys<=8) ) ? selectedJets_noSys_unsorted : miniAODhelper.GetSelectedJets(correctedJets, 20., 5.0 , jetID::none, '-' );
 
 
@@ -1353,7 +1353,7 @@ n_fatjets++;
     // pat::MET correctedMET = pfmet->front();//miniAODhelper.GetCorrectedMET( pfmets.at(0), pfJets_forMET, iSysType );
     std::vector<pat::Jet> oldJetsForMET = miniAODhelper.GetSelectedJets(*pfjets, 0., 999, jetID::jetMETcorrection, '-' );
     std::vector<pat::Jet> oldJetsForMET_uncorr = miniAODhelper.GetUncorrectedJets(oldJetsForMET);
-    std::vector<pat::Jet> newJetsForMET = miniAODhelper.GetCorrectedJets(oldJetsForMET_uncorr, iEvent, iSetup, iSysType);
+    std::vector<pat::Jet> newJetsForMET = miniAODhelper.GetCorrectedJets(oldJetsForMET_uncorr, iEvent, iSetup, genjetCollection, iSysType);
     std::vector<pat::MET> newMETs = miniAODhelper.CorrectMET(oldJetsForMET, newJetsForMET, *pfmet);
 
     pat::MET correctedMET = newMETs.at(0); 
@@ -1620,9 +1620,9 @@ n_fatjets++;
       const bool  doJES = true;
       const bool  doJER = false;
 
-      std::vector<pat::Jet> jet_JESNOMI =  miniAODhelper.GetCorrectedJets(rawJets, iEvent, iSetup, sysType::NA     , doJES, doJER );
-      std::vector<pat::Jet> jet_JESUP   =  miniAODhelper.GetCorrectedJets(rawJets, iEvent, iSetup, sysType::JESup  , doJES, doJER );
-      std::vector<pat::Jet> jet_JESDOWN =  miniAODhelper.GetCorrectedJets(rawJets, iEvent, iSetup, sysType::JESdown, doJES, doJER );
+      std::vector<pat::Jet> jet_JESNOMI =  miniAODhelper.GetCorrectedJets(rawJets, iEvent, iSetup, genjetCollection , sysType::NA     , doJES, doJER );
+      std::vector<pat::Jet> jet_JESUP   =  miniAODhelper.GetCorrectedJets(rawJets, iEvent, iSetup, genjetCollection , sysType::JESup  , doJES, doJER );
+      std::vector<pat::Jet> jet_JESDOWN =  miniAODhelper.GetCorrectedJets(rawJets, iEvent, iSetup, genjetCollection , sysType::JESdown, doJES, doJER );
       if( nJet_ge_one ){
 
 	const double eta1 = selection.jets().at(0)->Eta();


### PR DESCRIPTION
Updated YggdrasilTreeMaker.cc according to update of MiniAODHeler interfarce (Reco/Gen jet matching issue).
This modification **should be merged AFTER update of MiniAODHelper**.
- git@github.com:abhisek92datta/MiniAOD.git 
- branch  : CMSSW_8_0_8_GenJet_Matching

+++++++++++

Here is a dump of variables before and after the modification.
Since this modification to the MiniAODHeler supposes not to affect most of the event,
 the result should be identical in most of the case.

 input : /store/mc/RunIIFall15MiniAODv2/TT_TuneCUETP8M1_13TeV-powheg-pythia8/MINIAODSIM/PU25nsData2015v1_76X_mcRun2_asymptotic_v12_ext3-v1/00000/00DF0A73-17C2-E511-B086-E41D2D08DE30.root

 second event.

Before and after the modification : 

run,lumi,event,is_e,is_mu,is_ee,is_emu,is_mumu,n_jets,n_btags,lep1_pt,lep1_iso,lep1_pdgId,lep2_pt,lep2_iso,lep2_pdgId,jet1_pt,jet2_pt,jet1_CSVv2,jet2_CSVv2,jet1_JecSF,jet1_JecSF_up,jet1_JecSF_down,MET_pt,MET_phi,mll,ttHFCategory,PUWeight,bWeight,topWeight,triggerSF,lepIDSF,lepISOSF,Q2_upup,Q2_downdown,pdf_up,pdf_down

1,27631,5503354,0,0,0,0,0,4,2,-1,-1,-1,-1,-1,-1,98.2711,76.3042,0.7308,0.8680,1.0818,1.0133,0.9867,42.0117,3.0622,10200,0.6395,0.8537,1.0000,1.0000,1.0000,1.0000,193.2465,0.1125,1.0160,0.9838

1,27631,5503354,0,0,0,0,0,4,2,-1,-1,-1,-1,-1,-1,98.2711,76.3042,0.7308,0.8680,1.0818,1.0133,0.9867,42.0117,3.0622,10200,0.6395,0.8537,1.0000,1.0000,1.0000,1.0000,197.0207,0.1211,1.0160,0.9838
